### PR TITLE
fix clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -65,10 +65,9 @@ SpacesInCStyleCastParentheses: false
 SpacesInConditionalStatement: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
-Standard: c++23
+Standard: c++20
 UseCRLF: false
 UseTab: Never
-BreakBeforeBraces: Custom
 BraceWrapping:
   AfterCaseLabel: false
   AfterClass: false


### PR DESCRIPTION
`BreakBeforeBraces`が重複していたので削除しました。
また、最新のclang-formatでもc++23は認識できないようです。
https://clang.llvm.org/docs/ClangFormatStyleOptions.html#standard
