### PR TITLE
use gnu++2b because clangd doesn't understand gnu++23.

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,7 +16,7 @@ platform = ststm32
 board = nucleo_f446re
 framework = mbed
 monitor_speed = 115200
-build_flags = -std=gnu++23
+build_flags = -std=gnu++2b
 build_unflags = -std=gnu++14
 extra_scripts = pre:extra_script.py
 platform_packages =


### PR DESCRIPTION
https://cpprefjp.github.io/implementation.html