### PR TITLE
improve amt21

### DIFF
--- a/src/amt21.hpp
+++ b/src/amt21.hpp
@@ -27,14 +27,16 @@ class Amt21 {
   }
 
   bool update_pos() {
-    rs485_->flush_read_buffer();
-    rs485_->send(&address_, 1);
-    if(uint16_t resp; rs485_->recv(&resp, sizeof(resp), 100us) && (is_valid(resp))) {
-      uint16_t ticks = (resp & 0b0011'1111'1111'1111) >> 2;
-      auto dir = Direction::from_rad(ticks * ticks_to_rads);
-      raw_angle_ = raw_angle_.closest_angle_of(dir);
-      angle_ = raw_angle_ * scale_ + offset_;
-      return true;
+    for (size_t i = 0; i < 3; ++i) {
+      rs485_->flush_read_buffer();
+      rs485_->send(&address_, 1);
+      if(uint16_t resp; rs485_->recv(&resp, sizeof(resp), 20us) && (is_valid(resp))) {
+        uint16_t ticks = (resp & 0b0011'1111'1111'1111) >> 2;
+        auto dir = Direction::from_rad(ticks * ticks_to_rads);
+        raw_angle_ = raw_angle_.closest_angle_of(dir);
+        angle_ = raw_angle_ * scale_ + offset_;
+        return true;
+      }
     }
     return false;
   }

--- a/src/rs485.hpp
+++ b/src/rs485.hpp
@@ -13,7 +13,7 @@ struct Rs485 {
   void send(void* buf, const int len) {
     data_enable_.write(1);
     bus_.write(buf, len);
-    wait_us(5);
+    wait_us(6);
     data_enable_.write(0);
   }
 
@@ -36,11 +36,11 @@ struct Rs485 {
 
   void flush_read_buffer() {
     uint8_t buf;
-    while(bus_.read(&buf, 1) > 0) {}
+    while(bus_.readable() && bus_.read(&buf, 1) > 0) {}
   }
 
   Timer timer;
-  BufferedSerial bus_;
+  UnbufferedSerial bus_;
   DigitalOut data_enable_;
 };
 


### PR DESCRIPTION
- `BufferedSerial`の代わりに`UnbufferedSerial`を使用する
- 読み取りエラーのときに3回までリトライする
- タイムアウトの秒数を微調整